### PR TITLE
Update research.html template to allow for links to PDF files

### DIFF
--- a/_includes/research.html
+++ b/_includes/research.html
@@ -16,18 +16,20 @@
                 </div>
             </div>
             {% for topic in site.data.research.topics %}
+                {% if topic.topic %}
                 <div class="row">
                     <div class="col-lg-10 col-lg-offset-1">
                         <h2>{{topic.topic}}</h2>
                         <br>
                     </div>
                 </div>
+                {% endif %}
                 <div class="row">
                     {% if topic.picture %}
                     <div class="col-lg-2 col-lg-push-9 col-sm-3 col-sm-push-9 col-xs-6">
                         <span style="width:100%; height: auto">
                           {% if topic.link %}
-                          <a href="{{topic.link}}">
+                          <a href="{{topic.link}}" target="_blank">
                             <img src="./img/research/{{topic.picture}}" style="width:100%; height: auto">
                           </a>
                           {% else %}


### PR DESCRIPTION
Quick change to:
1. Allow for subsections in the research section to not have titles
2. Add target="blank" for all image links, ensuring these open in a new tab